### PR TITLE
fix package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ I am presenting at Linux.conf.au 2018 in Sydney.
 To build the code, install some pre-requisites
 
 Fedora:
-  dnf install gstreamer-tools gstreamer1-devel gstreamer1-plugins-\* gstreamer1-libav gstreamer1-rtsp-server gstreamer1-rtsp-server-devel
+  dnf install gstreamer-tools gstreamer1-devel gstreamer1-plugins-\\* gstreamer1-libav gstreamer1-rtsp-server gstreamer1-rtsp-server-devel
 
 Debian:
-  apt-get install gstreamer1.0-tools libgstreamer1.0-dev gstreamer1.0-plugins-\* gstreamer1.0-libav libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev
+  apt-get install gstreamer1.0-tools libgstreamer1.0-dev gstreamer1.0-plugins-\\* gstreamer1.0-libav libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev


### PR DESCRIPTION
We need to add a double backslash (`\`) to display it in markdown format.